### PR TITLE
Added mock ShardManager classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ts</groupId>
 	<artifactId>cxgo-spring-boot-sdk</artifactId>
-	<version>0.1.34</version>
+	<version>0.1.35</version>
 	<name>cxgo-spring-boot-sdk</name>
 	<description>CxGo Java Spring Boot SDK</description>
 

--- a/src/main/java/com/checkmarx/sdk/ShardManager/ShardSession.java
+++ b/src/main/java/com/checkmarx/sdk/ShardManager/ShardSession.java
@@ -1,0 +1,11 @@
+package com.checkmarx.sdk.ShardManager;
+
+public class ShardSession {
+    public void setTeam(String team) {
+        // does nothing by design
+    }
+
+    public void setProject(String project) {
+        // does nothing by design
+    }
+}

--- a/src/main/java/com/checkmarx/sdk/ShardManager/ShardSessionTracker.java
+++ b/src/main/java/com/checkmarx/sdk/ShardManager/ShardSessionTracker.java
@@ -1,0 +1,14 @@
+package com.checkmarx.sdk.ShardManager;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ShardSessionTracker {
+
+    //
+    /// This doesn't exist in the CxGO world.
+    //
+    public ShardSession getShardSession() {
+        return null;
+    }
+}
+


### PR DESCRIPTION
CxFlow requires stubbed classes for ScanRequestConverter.java to compile correctly.